### PR TITLE
Repairing the single resource of the operation caused issues for all instances. 

### DIFF
--- a/tools/c7n_huaweicloud/c7n_huaweicloud/resources/ces.py
+++ b/tools/c7n_huaweicloud/c7n_huaweicloud/resources/ces.py
@@ -937,4 +937,3 @@ class CreateVpcEventAlarmRule(BaseAction):
             log.error(f"[actions]- {actionName}- The resource:{resourceType} "
                       f"with id:alarm-vpc-change  {doSomeThing}  is failed. cause: {e.error_msg} ")
             raise e
-


### PR DESCRIPTION
Repairing the single resource of the operation caused issues for all instances. 