### PR TITLE
Pin huaweicloudsdkcore dependency to 3.1.189

### DIFF
--- a/tools/c7n_huaweicloud/pyproject.toml
+++ b/tools/c7n_huaweicloud/pyproject.toml
@@ -73,6 +73,7 @@ huaweicloudsdkcodehub = "3.1.164"
 huaweicloudsdkcodeartsbuild = "3.1.162"
 huaweicloudsdkaos = "3.1.167"
 huaweicloudsdkgaussdbfornosql = "3.1.184"
+huaweicloudsdkcore = "3.1.189"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "<8.0"


### PR DESCRIPTION
## Description

This PR is a quick fix for the error `Unexpected error during assume role: 'Credentials' object has no attribute 'update_security_token_from_metadata'` when running c7n-org, as shown below:

```
(custodian) $ c7n-org run -c accounts.yml -s ./output -u policies.yml --dryrun --cache-period=0
2026-08-14 03:14:10,584: c7n_org:INFO Using Huawei Cloud agency: iam::ACCOUNT_ID:agency:AGENCY_NAME
2026-08-14 03:14:10,597: custodian.huaweicloud.provider:ERROR Unexpected error during assume role: 'Credentials' object has no attribute 'update_security_token_from_metadata'
2026-08-14 03:14:10,597: c7n_org:ERROR Exception running policy:POLICY_NAME account:ACCOUNT_NAME region:sa-brazil-1 error:'Credentials' object has no attribute 'update_security_token_from_metadata'
2026-08-14 03:14:10,660: c7n_org:INFO === Policy Execution Results ===
...
```

### Root Cause

When installing the dependencies of `tools/c7n_huaweicloud`, the latest version of `huaweicloudsdkcore` is installed (as of today, it's 3.1.210). However, the `update_security_token_from_metadata` method from Credentials class of `huaweicloudsdkcore/auth/credentials.py` was removed in version 3.1.190, as seen in the [following diff](https://github.com/huaweicloud/huaweicloud-sdk-python-v3/commit/16bbf764d5565cf821a60ba4578bc02c527ff022#diff-0bb579d95127bd012aa959094f2180b3c546e870847f57599b5604b685614b97) (search for `credentials` in the **Filter Files...** field on the left side):

<img width="1825" height="813" alt="image" src="https://github.com/user-attachments/assets/eab3544a-44b7-4940-a1ba-da3eea4ff60e" />

### Solution

Fix the huaweiclousdkcore package version to 3.1.189 in the `tools/c7n_huaweicloud/pyproject.toml` file.
